### PR TITLE
✨ feat: Add arXiv Research Papers Integration

### DIFF
--- a/ai_news_curator.py
+++ b/ai_news_curator.py
@@ -13,12 +13,13 @@ from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 import feedparser
 import requests
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
 # override=True ensures .env takes precedence over shell variables
 load_dotenv(override=True)
+
 
 @dataclass
 class NewsItem:
@@ -31,36 +32,35 @@ class NewsItem:
     category: str  # "teaching", "tools", "research", "skip"
     reasoning: str
 
+
 class AINewsCurator:
-    def __init__(self, anthropic_api_key: str, prompt_template_path: str = "prompt_template.txt"):
+    def __init__(
+        self, anthropic_api_key: str, prompt_template_path: str = "prompt_template.txt"
+    ):
         self.client = anthropic.Anthropic(api_key=anthropic_api_key)
         self.sources = {
             # Official Blogs & News
-            'anthropic_blog': 'https://www.anthropic.com/news/rss',
-            'openai_blog': 'https://openai.com/blog/rss',
-            'google_ai': 'https://blog.google/technology/ai/rss',
-            'google_developers': 'https://developers.googleblog.com/feeds/posts/default',
-
+            "anthropic_blog": "https://www.anthropic.com/news/rss",
+            "openai_blog": "https://openai.com/blog/rss",
+            "google_ai": "https://blog.google/technology/ai/rss",
+            "google_developers": "https://developers.googleblog.com/feeds/posts/default",
             # AI News Aggregators
-            'hacker_news_ai': 'https://hnrss.org/newest?q=AI+OR+LLM+OR+Claude+OR+GPT+OR+Cursor+OR+Windsurf',
-            'last_week_in_ai': 'https://lastweekin.ai/feed',
-            'daily_dose_ds': 'https://blog.dailydoseofds.com/feed',
-
+            "hacker_news_ai": "https://hnrss.org/newest?q=AI+OR+LLM+OR+Claude+OR+GPT+OR+Cursor+OR+Windsurf",
+            "last_week_in_ai": "https://lastweekin.ai/feed",
+            "daily_dose_ds": "https://blog.dailydoseofds.com/feed",
             # Developer News
-            'infoq_llm': 'https://www.infoq.com/llms/rss',
-            'thenewstack': 'https://thenewstack.io/blog/feed/',
-
+            "infoq_llm": "https://www.infoq.com/llms/rss",
+            "thenewstack": "https://thenewstack.io/blog/feed/",
             # Tech News
-            'techcrunch_ai': 'https://techcrunch.com/category/artificial-intelligence/feed/',
-            'venturebeat_ai': 'https://venturebeat.com/category/ai/feed/',
-
+            "techcrunch_ai": "https://techcrunch.com/category/artificial-intelligence/feed/",
+            "venturebeat_ai": "https://venturebeat.com/category/ai/feed/",
             # Research Papers
-            'arxiv_cs_ai': 'https://rss.arxiv.org/rss/cs.AI',
+            "arxiv_cs_ai": "https://rss.arxiv.org/rss/cs.AI",
         }
 
         # Load prompt template from file
         try:
-            with open(prompt_template_path, 'r', encoding='utf-8') as f:
+            with open(prompt_template_path, "r", encoding="utf-8") as f:
                 self.prompt_template = f.read()
         except FileNotFoundError:
             print(f"⚠️  Warning: Prompt template not found at {prompt_template_path}")
@@ -115,15 +115,15 @@ Format:
         # Parse the last N reports
         for report_file in report_files[:days_back]:
             try:
-                with open(report_file, 'r', encoding='utf-8') as f:
+                with open(report_file, "r", encoding="utf-8") as f:
                     content = f.read()
                     # Extract URLs from Markdown links: [Link](url)
-                    urls = re.findall(r'\[Link\]\((https?://[^\)]+)\)', content)
+                    urls = re.findall(r"\[Link\]\((https?://[^\)]+)\)", content)
                     seen_urls.update(urls)
                     # Extract titles from Markdown headers: ### emoji Title
-                    titles = re.findall(r'### [^\s]+ (.+)', content)
+                    titles = re.findall(r"### [^\s]+ (.+)", content)
                     seen_titles.extend([title.strip() for title in titles])
-            except Exception as e:
+            except Exception:
                 continue
 
         return seen_urls, seen_titles
@@ -137,7 +137,7 @@ Format:
             pass
 
         # Suche nach JSON-Block im Text (zwischen geschweiften Klammern)
-        json_pattern = r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}'
+        json_pattern = r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}"
         matches = re.finditer(json_pattern, text, re.DOTALL)
 
         for match in matches:
@@ -148,7 +148,7 @@ Format:
                 continue
 
         return None
-    
+
     def fetch_news(self, hours_back: int = 168) -> (List[Dict], list):
         """Sammelt News von verschiedenen Quellen (Standard: 7 Tage für Weekly Digest)"""
         news_items = []
@@ -156,13 +156,16 @@ Format:
         # Load URLs from previous reports to avoid duplicates
         print("🔍 Checking for duplicates in previous reports...")
         seen_urls, seen_titles = self.load_previous_news(days_back=14)
-        print(f"   Found {len(seen_urls)} URLs and {len(seen_titles)} titles in previous reports")
+        print(
+            f"   Found {len(seen_urls)} URLs and {len(seen_titles)} titles in previous reports"
+        )
 
         cutoff_date = datetime.now() - timedelta(hours=hours_back)
 
         # Limit items per source (Google and arXiv sources are limited to reduce dominance)
-        google_sources = {'google_ai', 'google_developers'}
-        arxiv_sources = {'arxiv_cs_ai', 'arxiv_cs_lg', 'arxiv_cs_cl'}
+        google_sources = {"google_ai", "google_developers"}
+        # Derive arxiv_sources dynamically from configured sources to stay in sync
+        arxiv_sources = {name for name in self.sources if name.startswith("arxiv_")}
 
         # Fetch from all RSS feeds
         print(f"📡 Fetching from {len(self.sources)} RSS sources...")
@@ -180,9 +183,12 @@ Format:
                 for entry in feed.entries[:max_items]:
                     try:
                         # Parse publication date
-                        if hasattr(entry, 'published_parsed') and entry.published_parsed:
+                        if (
+                            hasattr(entry, "published_parsed")
+                            and entry.published_parsed
+                        ):
                             pub_date = datetime(*entry.published_parsed[:6])
-                        elif hasattr(entry, 'updated_parsed') and entry.updated_parsed:
+                        elif hasattr(entry, "updated_parsed") and entry.updated_parsed:
                             pub_date = datetime(*entry.updated_parsed[:6])
                         else:
                             # If no date, use current time
@@ -193,30 +199,37 @@ Format:
                             continue
 
                         # Get URL and check for duplicates
-                        url = entry.get('link', '')
+                        url = entry.get("link", "")
                         if not url or url in seen_urls:
                             continue
 
                         seen_urls.add(url)
 
                         # Extract summary
-                        summary = entry.get('summary', entry.get('description', ''))
+                        summary = entry.get("summary", entry.get("description", ""))
                         if not summary:
-                            summary = entry.get('content', [{}])[0].get('value', '') if entry.get('content') else ''
+                            summary = (
+                                entry.get("content", [{}])[0].get("value", "")
+                                if entry.get("content")
+                                else ""
+                            )
 
                         # Clean HTML tags from summary
                         import re
-                        summary = re.sub(r'<[^>]+>', '', summary)
 
-                        news_items.append({
-                            'title': entry.title,
-                            'url': url,
-                            'source': source_name.replace('_', ' ').title(),
-                            'published': pub_date.isoformat(),
-                            'summary': summary[:500]
-                        })
+                        summary = re.sub(r"<[^>]+>", "", summary)
+
+                        news_items.append(
+                            {
+                                "title": entry.title,
+                                "url": url,
+                                "source": source_name.replace("_", " ").title(),
+                                "published": pub_date.isoformat(),
+                                "summary": summary[:500],
+                            }
+                        )
                         count += 1
-                    except Exception as e:
+                    except Exception:
                         # Skip individual entry errors
                         continue
 
@@ -224,58 +237,66 @@ Format:
                     print(f"  ✓ {source_name}: {count} items")
             except Exception as e:
                 print(f"  ✗ {source_name}: {str(e)[:50]}")
-        
+
         # GitHub Trending
-        print(f"📡 Fetching GitHub trending repositories...")
+        print("📡 Fetching GitHub trending repositories...")
         try:
             gh_url = "https://api.github.com/search/repositories"
             params = {
-                'q': 'ai OR llm OR claude OR cursor OR windsurf OR antigravity created:>=' + cutoff_date.strftime('%Y-%m-%d'),
-                'sort': 'stars',
-                'order': 'desc',
-                'per_page': 15
+                "q": "ai OR llm OR claude OR cursor OR windsurf OR antigravity created:>="
+                + cutoff_date.strftime("%Y-%m-%d"),
+                "sort": "stars",
+                "order": "desc",
+                "per_page": 15,
             }
             response = requests.get(gh_url, params=params)
             if response.ok:
                 gh_count = 0
-                for repo in response.json().get('items', []):
-                    url = repo['html_url']
+                for repo in response.json().get("items", []):
+                    url = repo["html_url"]
                     if url not in seen_urls:
                         seen_urls.add(url)
-                        news_items.append({
-                            'title': f"📦 {repo['full_name']}: {repo['description'][:100] if repo['description'] else 'No description'}",
-                            'url': url,
-                            'source': 'GitHub Trending',
-                            'published': repo['created_at'],
-                            'summary': repo['description'] or 'No description available'
-                        })
+                        news_items.append(
+                            {
+                                "title": f"📦 {repo['full_name']}: {repo['description'][:100] if repo['description'] else 'No description'}",
+                                "url": url,
+                                "source": "GitHub Trending",
+                                "published": repo["created_at"],
+                                "summary": repo["description"]
+                                or "No description available",
+                            }
+                        )
                         gh_count += 1
                 print(f"  ✓ GitHub: {gh_count} repos")
             else:
                 print(f"  ✗ GitHub: HTTP {response.status_code}")
         except Exception as e:
             print(f"  ✗ GitHub: {str(e)[:50]}")
-        
+
         # Reddit r/LocalLLaMA top posts
-        print(f"📡 Fetching Reddit r/LocalLLaMA...")
+        print("📡 Fetching Reddit r/LocalLLaMA...")
         try:
             reddit_url = "https://www.reddit.com/r/LocalLLaMA/top.json?t=day&limit=15"
-            headers = {'User-Agent': 'AI-News-Curator/2.0'}
+            headers = {"User-Agent": "AI-News-Curator/2.0"}
             response = requests.get(reddit_url, headers=headers)
             if response.ok:
                 reddit_count = 0
-                for post in response.json().get('data', {}).get('children', []):
-                    data = post['data']
+                for post in response.json().get("data", {}).get("children", []):
+                    data = post["data"]
                     url = f"https://reddit.com{data['permalink']}"
                     if url not in seen_urls:
                         seen_urls.add(url)
-                        news_items.append({
-                            'title': data['title'],
-                            'url': url,
-                            'source': 'Reddit r/LocalLLaMA',
-                            'published': datetime.fromtimestamp(data['created_utc']).isoformat(),
-                            'summary': data.get('selftext', '')[:500]
-                        })
+                        news_items.append(
+                            {
+                                "title": data["title"],
+                                "url": url,
+                                "source": "Reddit r/LocalLLaMA",
+                                "published": datetime.fromtimestamp(
+                                    data["created_utc"]
+                                ).isoformat(),
+                                "summary": data.get("selftext", "")[:500],
+                            }
+                        )
                         reddit_count += 1
                 print(f"  ✓ Reddit: {reddit_count} posts")
             else:
@@ -283,10 +304,14 @@ Format:
         except Exception as e:
             print(f"  ✗ Reddit: {str(e)[:50]}")
 
-        print(f"\n✅ Total fetched: {len(news_items)} unique items from {len(self.sources) + 2} sources")
+        print(
+            f"\n✅ Total fetched: {len(news_items)} unique items from {len(self.sources) + 2} sources"
+        )
         return news_items, seen_titles
-    
-    def analyze_relevance(self, news_items: List[Dict], seen_titles: list) -> List[NewsItem]:
+
+    def analyze_relevance(
+        self, news_items: List[Dict], seen_titles: list
+    ) -> List[NewsItem]:
         """Nutzt Claude API um Relevanz zu bewerten"""
 
         filtered_items = []
@@ -303,17 +328,17 @@ Format:
 
             # Use template and fill in the news item details
             prompt = self.prompt_template.format(
-                title=item['title'],
-                source=item['source'],
-                summary=item['summary'][:300],
-                recent_news=seen_titles_text
+                title=item["title"],
+                source=item["source"],
+                summary=item["summary"][:300],
+                recent_news=seen_titles_text,
             )
 
             try:
                 response = self.client.messages.create(
                     model="claude-sonnet-4-20250514",
                     max_tokens=400,
-                    messages=[{"role": "user", "content": prompt}]
+                    messages=[{"role": "user", "content": prompt}],
                 )
 
                 # Verbesserte JSON-Extraktion
@@ -321,25 +346,29 @@ Format:
                 analysis = self.extract_json_from_text(response_text)
 
                 if not analysis:
-                    raise ValueError(f"Konnte kein JSON in Response finden: {response_text[:100]}")
+                    raise ValueError(
+                        f"Konnte kein JSON in Response finden: {response_text[:100]}"
+                    )
 
                 # Validierung der erforderlichen Felder
-                if 'relevance_score' not in analysis or 'category' not in analysis:
+                if "relevance_score" not in analysis or "category" not in analysis:
                     raise ValueError(f"JSON fehlt erforderliche Felder: {analysis}")
 
                 # Fallback für fehlendes reasoning
-                reasoning = analysis.get('reasoning', 'Keine Begründung verfügbar')
+                reasoning = analysis.get("reasoning", "Keine Begründung verfügbar")
 
-                filtered_items.append(NewsItem(
-                    title=item['title'],
-                    url=item['url'],
-                    source=item['source'],
-                    published=item['published'],
-                    summary=item['summary'][:200],
-                    relevance_score=int(analysis['relevance_score']),
-                    category=analysis['category'],
-                    reasoning=reasoning
-                ))
+                filtered_items.append(
+                    NewsItem(
+                        title=item["title"],
+                        url=item["url"],
+                        source=item["source"],
+                        published=item["published"],
+                        summary=item["summary"][:200],
+                        relevance_score=int(analysis["relevance_score"]),
+                        category=analysis["category"],
+                        reasoning=reasoning,
+                    )
+                )
                 success_count += 1
 
             except Exception as e:
@@ -349,22 +378,26 @@ Format:
                     print(f"⚠️  Error analyzing '{item['title'][:50]}...': {e}")
 
                 # Fallback: Füge Item mit niedrigem Score hinzu statt es zu verlieren
-                filtered_items.append(NewsItem(
-                    title=item['title'],
-                    url=item['url'],
-                    source=item['source'],
-                    published=item['published'],
-                    summary=item['summary'][:200],
-                    relevance_score=1,  # Niedrigster Score
-                    category='skip',
-                    reasoning=f'Automatische Analyse fehlgeschlagen: {str(e)[:100]}'
-                ))
+                filtered_items.append(
+                    NewsItem(
+                        title=item["title"],
+                        url=item["url"],
+                        source=item["source"],
+                        published=item["published"],
+                        summary=item["summary"][:200],
+                        relevance_score=1,  # Niedrigster Score
+                        category="skip",
+                        reasoning=f"Automatische Analyse fehlgeschlagen: {str(e)[:100]}",
+                    )
+                )
 
-        print(f"📊 Analyse-Statistik: {success_count} erfolgreich, {error_count} Fehler")
+        print(
+            f"📊 Analyse-Statistik: {success_count} erfolgreich, {error_count} Fehler"
+        )
 
         # Sortiere nach Relevanz
         return sorted(filtered_items, key=lambda x: x.relevance_score, reverse=True)
-    
+
     def generate_report(self, analyzed_items: List[NewsItem]) -> str:
         """Erstellt Markdown-Report"""
 
@@ -385,19 +418,19 @@ Format:
 
         # Kategorien-Emojis für bessere Übersicht
         category_emojis = {
-            'llm_release': '🤖',
-            'cli_tools': '⌨️',
-            'teaching': '🎓',
-            'tools': '🛠️',
-            'research': '🔬',
-            'frameworks': '📦'
+            "llm_release": "🤖",
+            "cli_tools": "⌨️",
+            "teaching": "🎓",
+            "tools": "🛠️",
+            "research": "🔬",
+            "frameworks": "📦",
         }
 
         if not high_priority:
             report += "_Keine hochprioritäre Updates heute._\n\n"
         else:
             for item in high_priority:
-                emoji = category_emojis.get(item.category, '📌')
+                emoji = category_emojis.get(item.category, "📌")
                 report += f"""### {emoji} {item.title}
 **Quelle:** {item.source} | **Score:** {item.relevance_score}/5 | **Kategorie:** {item.category}
 
@@ -417,7 +450,7 @@ Format:
             report += "_Keine mittelprioritäre Updates._\n\n"
         else:
             for item in medium_priority:
-                emoji = category_emojis.get(item.category, '📌')
+                emoji = category_emojis.get(item.category, "📌")
                 report += f"- {emoji} **{item.title}** ([Link]({item.url})) - {item.reasoning}\n"
 
         # Kategorien-Statistik
@@ -435,48 +468,48 @@ Format:
 **Nach Kategorien:**
 """
         for cat, count in sorted(categories.items(), key=lambda x: x[1], reverse=True):
-            emoji = category_emojis.get(cat, '📌')
+            emoji = category_emojis.get(cat, "📌")
             report += f"- {emoji} {cat}: {count}\n"
 
         report += "\n_Generiert mit Claude API | Talent Factory GmbH_\n"
 
         return report
-    
+
     def run(self, hours_back: int = 24) -> str:
         """Hauptfunktion - führt gesamten Workflow aus"""
         print(f"🔍 Sammle News der letzten {hours_back} Stunden...")
         news_items, seen_titles = self.fetch_news(hours_back)
         print(f"✅ {len(news_items)} Items gefunden")
-        
+
         print("🤖 Analysiere Relevanz mit Claude...")
         analyzed_items = self.analyze_relevance(news_items, seen_titles)
         print(f"✅ {len(analyzed_items)} Items analysiert")
-        
+
         print("📝 Generiere Report...")
         report = self.generate_report(analyzed_items)
-        
+
         # Speichere Report
         output_file = f"ai_news_digest_{datetime.now().strftime('%Y%m%d')}.md"
-        with open(output_file, 'w', encoding='utf-8') as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             f.write(report)
-        
+
         print(f"✅ Report gespeichert: {output_file}")
         return report
 
 
 def main():
     # API Key aus Environment Variable
-    api_key = os.getenv('ANTHROPIC_API_KEY')
+    api_key = os.getenv("ANTHROPIC_API_KEY")
     if not api_key:
         print("❌ Error: ANTHROPIC_API_KEY environment variable nicht gesetzt!")
         print("Setze mit: export ANTHROPIC_API_KEY='dein-key'")
         return
-    
+
     curator = AINewsCurator(api_key)
     report = curator.run(hours_back=24)
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print(report[:500] + "...")
-    print("="*60)
+    print("=" * 60)
 
 
 if __name__ == "__main__":

--- a/ai_news_curator.py
+++ b/ai_news_curator.py
@@ -53,6 +53,9 @@ class AINewsCurator:
             # Tech News
             'techcrunch_ai': 'https://techcrunch.com/category/artificial-intelligence/feed/',
             'venturebeat_ai': 'https://venturebeat.com/category/ai/feed/',
+
+            # Research Papers
+            'arxiv_cs_ai': 'https://rss.arxiv.org/rss/cs.AI',
         }
 
         # Load prompt template from file
@@ -157,8 +160,9 @@ Format:
 
         cutoff_date = datetime.now() - timedelta(hours=hours_back)
 
-        # Limit items per source (Google sources are limited to reduce dominance)
+        # Limit items per source (Google and arXiv sources are limited to reduce dominance)
         google_sources = {'google_ai', 'google_developers'}
+        arxiv_sources = {'arxiv_cs_ai', 'arxiv_cs_lg', 'arxiv_cs_cl'}
 
         # Fetch from all RSS feeds
         print(f"📡 Fetching from {len(self.sources)} RSS sources...")
@@ -166,7 +170,13 @@ Format:
             try:
                 feed = feedparser.parse(feed_url)
                 count = 0
-                max_items = 10 if source_name in google_sources else 20
+                # Limit arXiv to 10 items per source (too many theoretical papers)
+                if source_name in arxiv_sources:
+                    max_items = 10
+                elif source_name in google_sources:
+                    max_items = 10
+                else:
+                    max_items = 20
                 for entry in feed.entries[:max_items]:
                     try:
                         # Parse publication date

--- a/prompt_template.txt
+++ b/prompt_template.txt
@@ -68,6 +68,16 @@ BESONDERE RELEVANZ-KRITERIEN:
    - Jupyter/Notebook-Integration mit AI → RELEVANT
    - Data Analysis & Visualization mit AI → INTERESSANT
 
+6. RESEARCH PAPERS (arXiv):
+   - KRITISCH: NUR relevant wenn praktisch anwendbar UND Code verfügbar
+   - Neue Techniken für LLM-Development (Prompt Engineering, RAG, Fine-tuning) → RELEVANT
+   - Benchmark-Ergebnisse für bekannte Modelle (Claude, GPT, Gemini) → INTERESSANT
+   - Neue Architekturen MIT Open-Source Implementation → RELEVANT
+   - Rein theoretische Papers OHNE praktischen Use-Case → IMMER SKIP
+   - Papers OHNE Code/GitHub Link → MEIST SKIP
+   - DEFAULT Score für arXiv Papers: 2 (nicht 3!)
+   - Nur bei außergewöhnlich praktischer Relevanz höher bewerten
+
 BEREITS GEMELDETE NEWS (LETZTE 7 TAGE):
 {recent_news}
 
@@ -99,8 +109,8 @@ KATEGORIE:
 - "cli_tools" = Terminal/CLI-basierte Entwicklungsumgebungen
 - "teaching" = Direkt für Unterricht nutzbar (Tutorials, Patterns, Best Practices)
 - "tools" = Andere Development Tools, Extensions, Frameworks
-- "research" = Interessante Entwicklung, aber nicht unmittelbar praktisch
-- "skip" = Nicht relevant
+- "research" = Research Papers mit praktischer Anwendbarkeit (arXiv mit Code)
+- "skip" = Nicht relevant (inkl. theoretische Papers ohne Code)
 
 WICHTIG:
 - CLI-basierte Tools (Terminal, Command-Line) sind BESONDERS relevant für moderne Entwickler
@@ -108,6 +118,12 @@ WICHTIG:
 - "Agentic" Ansätze (autonome AI-Agents) sind wichtig für zukünftige Entwicklung
 - Praktische Tools > Theoretische Papers
 - Developer Experience > Academic Research
+
+BESONDERE REGEL FÜR arXiv PAPERS:
+- Frage: "Kann ein IT-Student das in 1-2 Wochen mit Code ausprobieren?"
+- Wenn NEIN → score = 1, category = "skip"
+- Nur wenn JA und praktisch relevant → score = 2-3, category = "research"
+- NIEMALS score 5 für Papers (außer revolutionäres Paper mit sofort nutzbarem Code)
 
 WICHTIG: Antworte AUSSCHLIESSLICH mit gültigem JSON. Kein Text davor oder danach.
 


### PR DESCRIPTION
## Beschreibung

Integration von arXiv Research Papers als neue Nachrichtenquelle für den AI News Curator. Die Änderungen stellen sicher, dass nur praktisch anwendbare Papers mit verfügbarem Code eine hohe Relevanz erhalten, während theoretische Papers ohne Code automatisch gefiltert werden.

## Änderungen

### ai_news_curator.py
- Neue RSS-Quelle hinzugefügt: `arxiv_cs_ai` (arXiv Computer Science - Artificial Intelligence)
- arXiv-Quellen auf maximal 10 Items pro Quelle begrenzt (analog zu Google-Quellen)
- Refactoring der max_items-Logik für bessere Lesbarkeit

### prompt_template.txt
- Neue Sektion "RESEARCH PAPERS (arXiv)" mit spezifischen Relevanz-Kriterien
- Strenge Filterregeln: Nur Papers mit praktischer Anwendbarkeit und Code erhalten Score > 2
- Default-Score für arXiv Papers auf 2 gesetzt (statt 3)
- Kategorie-Beschreibungen aktualisiert: "research" jetzt explizit für Papers mit Code
- Neue Filterregel: "Kann ein IT-Student das in 1-2 Wochen ausprobieren?"
- Score 5 für Papers praktisch ausgeschlossen (nur bei revolutionären Papers mit nutzbarem Code)

## Test-Plan

- [ ] `python ai_news_curator.py` ausführen und arXiv-Einträge im Digest prüfen
- [ ] Verifizieren, dass theoretische Papers (ohne Code) Score 1-2 und category "skip" erhalten
- [ ] Verifizieren, dass praktische Papers (mit GitHub-Link) Score 2-3 und category "research" erhalten
- [ ] Bestätigen, dass maximal 10 arXiv-Items pro Quelle gefetched werden

## Begründung

arXiv ist eine wichtige Quelle für aktuelle AI-Forschung, aber viele Papers sind zu theoretisch für den praktischen Einsatz in Schulungen. Diese Integration ermöglicht:
- Zugang zu aktuellen Research-Trends
- Automatische Filterung von Papers ohne praktischen Nutzen
- Fokus auf Papers mit verfügbarem Code für Hands-on-Übungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)