### PR TITLE
🐛 fix: Zurückgezogene Model-ID ersetzt - News-Curator lieferte leere Reports

### DIFF
--- a/ai_news_curator.py
+++ b/ai_news_curator.py
@@ -336,7 +336,7 @@ Format:
 
             try:
                 response = self.client.messages.create(
-                    model="claude-sonnet-4-20250514",
+                    model="claude-sonnet-4-6",
                     max_tokens=400,
                     messages=[{"role": "user", "content": prompt}],
                 )
@@ -394,6 +394,16 @@ Format:
         print(
             f"📊 Analyse-Statistik: {success_count} erfolgreich, {error_count} Fehler"
         )
+
+        # Fail loudly if EVERY analysis failed (e.g. retired/invalid model ID).
+        # Sonst würde ein leerer Report erzeugt und der Workflow täuschend "success"
+        # melden - genau das hat den wochenlangen Ausfall verschleiert.
+        if news_items and success_count == 0:
+            raise RuntimeError(
+                f"Claude-Analyse für alle {len(news_items)} Items fehlgeschlagen "
+                f"({error_count} Fehler). Vermutlich ungültige/zurückgezogene Model-ID "
+                f"oder API-Problem - siehe Fehlermeldungen oben."
+            )
 
         # Sortiere nach Relevanz
         return sorted(filtered_items, key=lambda x: x.relevance_score, reverse=True)


### PR DESCRIPTION
Die Model-ID claude-sonnet-4-20250514 (Claude Sonnet 4) wurde am
15. Juni 2026 zurückgezogen und liefert seither 404 not_found_error.
Dadurch schlug die Relevanz-Analyse für JEDES News-Item fehl, alle
Items landeten im Fallback (score=1, category=skip), und der Report
war leer ("Keine Updates") - seit rund zwei Wochen.

Änderungen:
- Model-ID auf claude-sonnet-4-6 aktualisiert (aktuelles Sonnet,
  gleiche Preis-Klasse)
- Guard ergänzt: Wenn die Analyse für ALLE Items fehlschlägt, bricht
  der Lauf jetzt mit RuntimeError ab statt still einen leeren Report
  zu erzeugen. So meldet der GitHub-Workflow künftig "failure" und der
  Ausfall fällt sofort auf, statt wochenlang unbemerkt zu bleiben.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013dsAjkSCWW7AXX4wW5yWc7